### PR TITLE
bump: version 1.0.2 → 1.0.3

### DIFF
--- a/.cz.changelog.md.j2
+++ b/.cz.changelog.md.j2
@@ -1,0 +1,19 @@
+{% for entry in tree %}
+
+## {{ entry.version }}{% if entry.date %} ({{ entry.date }}){% endif %}
+
+{% for change_key, changes in entry.changes.items() %}
+
+{% if change_key %}
+### {{ change_key.replace('Feat', 'Feature') }}
+{% endif %}
+
+{% for change in changes %}
+{% if change.scope %}
+- **{{ change.scope }}**: {{ change.message }}
+{% elif change.message %}
+- {{ change.message }}
+{% endif %}
+{% endfor %}
+{% endfor %}
+{% endfor %}

--- a/.cz.yaml
+++ b/.cz.yaml
@@ -7,7 +7,7 @@ commitizen:
   tag_format: v$version
   update_changelog_on_bump: true
   use_shortcuts: true
-  version: 1.0.2
+  version: 1.0.3
   version_files:
   - cmd/root.go
   version_scheme: semver

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Go",
-    "image": "mcr.microsoft.com/devcontainers/go:1.21",
+    "image": "mcr.microsoft.com/devcontainers/go:1-1.23",
     "runArgs": [ "--userns=keep-id" ],
     "customizations": {
         "vscode": {

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: trailing-whitespace
         args: [ --markdown-linebreak-ext=md ]
   - repo: https://github.com/golangci/golangci-lint
-    rev: 2059b18a39d559552839476ba78ce6acaa499b43  # frozen: v1.59.0
+    rev: eabc2638a66daf5bb6c6fb052a32fa3ef7b6600d  # frozen: v2.1.6
     hooks:
       - id: golangci-lint-full
   - repo: https://github.com/commitizen-tools/commitizen

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_install_hook_types:
   - commit-msg
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: 2c9f875913ee60ca25ce70243dc24d5b6415598c  # frozen: v4.6.0
+    rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b  # frozen: v5.0.0
     hooks:
       - id: check-added-large-files
       - id: check-json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     hooks:
       - id: golangci-lint-full
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: e9aa5d979ea6fd14dcf59c6bd3836bef17d386c1  # frozen: v3.27.0
+    rev: a8094aebad266040ef07f118a96c88a93f4aecf8  # frozen: v4.8.2
     hooks:
       - id: commitizen
         stages:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## v1.0.3 (2025-06-01)
+
+### Fix
+
+- update Go version from 1.21 to 1.23
+- **devcontainer**: bump Go image version from 1.21 to 1.23
+- **deps**: bump github.com/rs/zerolog from 1.33.0 to 1.34.0
+- **deps**: bump github.com/spf13/cobra from 1.8.0 to 1.9.1
+- **deps**: bump github.com/spf13/pflag from 1.0.5 to 1.0.6
+
 ## v1.0.2 (2024-05-27)
 
 ### Fix

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -168,7 +168,7 @@ func (r *results) printSet() error {
 
 var rootCmd = &cobra.Command{
 	Use:     "goDiffIt [fileA] [fileB]",
-	Version: "v1.0.2",
+	Version: "v1.0.3",
 	Short:   "goDiffIt is a CLI tool for comparing files/lists.",
 	Long: `goDiffIt is a CLI tool for comparing files/lists and explaining their differences. It can perform set operations such as
 union, intersection, and difference. This is very helpful for comparing data from different sources, and spotting gaps.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/JakeTRogers/goDiffIt
 
-go 1.21
+go 1.23
 
 require (
 	github.com/alexandrestein/gods v1.0.1


### PR DESCRIPTION
This pull request includes updates to dependencies, Go version, and configuration files, along with a version bump for the project. Below is a summary of the most important changes:

### Dependency and Version Updates:
* Updated Go version from `1.21` to `1.23` in `go.mod` and `.devcontainer/devcontainer.json`. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3) [[2]](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L3-R3)
* Bumped pre-commit hooks to newer versions in `.pre-commit-config.yaml`:
  - `pre-commit-hooks` updated to `v5.0.0`.
  - `golangci-lint` updated to `v2.1.6`.
  - `commitizen` updated to `v4.8.2`.

### Changelog Enhancements:
* Added a new templated changelog format in `.cz.changelog.md.j2` to dynamically generate changelogs.