### PR TITLE
Add CI workflow for Go tests and coverage, update dependabot and pre-commit configs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,11 @@ updates:
       prefix: "fix(deps)"
     cooldown:
       default-days: 10
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "ci(hooks)"
+    cooldown:
+      default-days: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,13 +3,12 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      # Check for updates to GitHub Actions every week
-      interval: "weekly"
+      interval: "monthly"
     commit-message:
       prefix: "ci(actions)"
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     commit-message:
       prefix: "fix(deps)"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,13 @@ updates:
       interval: "monthly"
     commit-message:
       prefix: "ci(actions)"
+    cooldown:
+      default-days: 10
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "monthly"
     commit-message:
       prefix: "fix(deps)"
+    cooldown:
+      default-days: 10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,54 @@
+name: Tests
+
+"on":
+  workflow_dispatch:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  go-test:
+    name: Run Go tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set Up Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run tests
+        run: go test ./... -v
+
+  go-coverage:
+    name: Run Go coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set Up Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run coverage
+        run: go test ./... -coverprofile=coverage.out
+
+      - name: Print coverage summary
+        run: go tool cover -func=coverage.out

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: trailing-whitespace
         args: [ --markdown-linebreak-ext=md ]
   - repo: https://github.com/golangci/golangci-lint
-    rev: 9f61b0f53f80672872fced07b6874397c3ed197b  # frozen: v2.7.2
+    rev: 6008b81b81c690c046ffc3fd5bce896da715d5fd  # frozen: v2.11.3
     hooks:
       - id: golangci-lint-full
   - repo: local

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
         types: [go]
         stages: [pre-commit]
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: 9f3ec868c0429155a46b4819b625d47a8522a3d5  # frozen: v4.10.0
+    rev: 4fbeae7861663ecf4b4989211eba41c1a3fb1227  # frozen: v4.13.9
     hooks:
       - id: commitizen
         stages:


### PR DESCRIPTION
Introduces a GitHub Actions workflow for Go testing and coverage, adds cooldowns and monthly intervals to dependabot, and updates pre-commit hooks and dependencies.

# Changes

## CI
- hooks: bump commitizen-tools/commitizen from v4.10.0 to v4.13.9
- hooks: bump golangci/golangci-lint from v2.7.2 to v2.11.3
- dependabot: add pre-commit configuration
- dependabot: add 10 day cooldown to all configurations
- dependabot: change interval to monthly